### PR TITLE
Fix AbstractMethodError on Hytale 0.5.6 (UPDATE 5)

### DIFF
--- a/src/main/java/to/dstn/hytale/hyrcon/DispatcherCommandExecutor.java
+++ b/src/main/java/to/dstn/hytale/hyrcon/DispatcherCommandExecutor.java
@@ -122,8 +122,8 @@ public final class DispatcherCommandExecutor implements CommandExecutor {
         }
 
         @Override
-        public String getDisplayName() {
-            return delegate.getDisplayName();
+        public String getUsername() {
+            return delegate.getUsername();
         }
 
         @Override


### PR DESCRIPTION
## Problem

On Hytale 0.5.6 (UPDATE 5), every RCON command fails with:

```
java.lang.AbstractMethodError: Receiver class to.dstn.hytale.hyrcon.DispatcherCommandExecutor$CollectingCommandSender does not define or inherit an implementation of the resolved method 'abstract java.lang.String getUsername()' of interface com.hypixel.hytale.server.core.command.system.CommandSender.
```

UPDATE 5 replaced `getDisplayName()` with `getUsername()` on the `CommandSender` interface, so `CollectingCommandSender` no longer satisfies the interface at runtime and `CommandManager.handleCommand` blows up on the ForkJoin worker thread before the command ever executes.

## Fix

- Implement `getUsername()` in `CollectingCommandSender`, delegating to the wrapped sender (same pattern as the other delegated methods)
- Remove the `getDisplayName()` override, which no longer exists on the interface

## Testing

Built against the 0.5.6 server jar and ran on a live 0.5.6 server — RCON clients connect, commands dispatch and return output correctly, and command exceptions are captured and reported over RCON instead of killing the worker thread.